### PR TITLE
Add support for testing response headers

### DIFF
--- a/dictionary.yml
+++ b/dictionary.yml
@@ -57,6 +57,20 @@ resources:
                       description: http response code (`200`)
                       type: number
 
+              - name: response_header
+                description: check http response headers
+                handle: checkResponseHeader
+                expressions:
+                    - $resource response header $header_name should be $header_value
+                parameters:
+                    - name: header_name
+                      description: http header name (`content-type`)
+                      type: string
+                    - name: header_value
+                      description: http header value (`application/json`)
+                      type: string
+
+
               - name: response_body
                 description: check response body
                 handle: checkResponseBody

--- a/docs/resources/http-client.md
+++ b/docs/resources/http-client.md
@@ -42,6 +42,12 @@ Given "$resourceName" send request to "$target" with payload
 Then "$resourceName" response code should be $statusCode
 ```
 
+* Check response header - to check header values of to a request that has been made
+
+```gherkin
+Then "$resourceName" repsonse header "$headerName" should be "$headerValue"
+```
+
 * Check response body - to check response body of request that been made
 ```gherkin
 Then "$resourceName" response body should be

--- a/examples/features/http.feature
+++ b/examples/features/http.feature
@@ -31,3 +31,10 @@ Feature: http feature example
                 "timestamp": "*"
             }
         """
+
+  Scenario: Test response header
+    Given set "tomato-http-server" with path "/status" response code to 200 and response body
+        """
+        """
+    Given "tomato-http-client" send request to "GET /status"
+    Given "tomato-http-client" response header "Content-Length" should be "0"

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,10 +1,9 @@
 /* GENERATED FILE - DO NOT EDIT */
-/* Rebuild from the tomatool generate handler tool */
+/* Rebuild from the cmd/gen/main.go tool */
 package handler
 
 import (
 	"github.com/DATA-DOG/godog"
-	"github.com/DATA-DOG/godog/gherkin"
 	"github.com/alileza/tomato/resource"
 )
 
@@ -15,16 +14,14 @@ type Handler struct {
 func New(r *resource.Manager) func(s *godog.Suite) {
 	h := &Handler{r}
 	return func(s *godog.Suite) {
-		s.BeforeFeature(func(_ *gherkin.Feature) {
-			h.resource.Reset()
-		})
-		s.AfterScenario(func(_ interface{}, _ error) {
+		s.BeforeScenario(func(_ interface{}) {
 			h.resource.Reset()
 		})
 		s.Step(`^"([^"]*)" send request to "([^"]*)"$`, h.sendRequest)
 		s.Step(`^"([^"]*)" send request to "([^"]*)" with body$`, h.sendRequestWithBody)
 		s.Step(`^"([^"]*)" send request to "([^"]*)" with payload$`, h.sendRequestWithBody)
 		s.Step(`^"([^"]*)" response code should be (\d+)$`, h.checkResponseCode)
+		s.Step(`^"([^"]*)" response header "([^"]*)" should be "([^"]*)"$`, h.checkResponseHeader)
 		s.Step(`^"([^"]*)" response body should be$`, h.checkResponseBody)
 		s.Step(`^set "([^"]*)" response code to (\d+) and response body$`, h.setResponse)
 		s.Step(`^set "([^"]*)" with path "([^"]*)" response code to (\d+) and response body$`, h.setResponse)

--- a/handler/http_client.go
+++ b/handler/http_client.go
@@ -36,7 +36,7 @@ func (h *Handler) checkResponseCode(resourceName string, expectedCode int) error
 	if err != nil {
 		return err
 	}
-	code, body, err := r.Response()
+	code, _, body, err := r.Response()
 	if err != nil {
 		return err
 	}
@@ -47,12 +47,29 @@ func (h *Handler) checkResponseCode(resourceName string, expectedCode int) error
 	return nil
 }
 
+func (h *Handler) checkResponseHeader(resourceName string, expectedHeaderName, expectedHeaderValue string) error {
+	r, err := h.resource.GetHTTPClient(resourceName)
+	if err != nil {
+		return err
+	}
+	_, header, body, err := r.Response()
+	if err != nil {
+		return err
+	}
+	hvalue := header.Get(expectedHeaderName)
+	if hvalue != expectedHeaderValue {
+		return fmt.Errorf("expecting response header %q to be %q, got %q\nresponse body : \n%s", expectedHeaderName, expectedHeaderValue, hvalue, string(body))
+	}
+
+	return nil
+}
+
 func (h *Handler) checkResponseBody(resourceName string, expectedBody *gherkin.DocString) error {
 	r, err := h.resource.GetHTTPClient(resourceName)
 	if err != nil {
 		return err
 	}
-	_, body, err := r.Response()
+	_, _, body, err := r.Response()
 	if err != nil {
 		return err
 	}

--- a/resource/http/client/client.go
+++ b/resource/http/client/client.go
@@ -12,8 +12,9 @@ import (
 )
 
 type response struct {
-	Code int
-	Body []byte
+	Code   int
+	Header http.Header
+	Body   []byte
 }
 
 type Client struct {
@@ -59,11 +60,11 @@ func (c *Client) Reset() error {
 	return nil
 }
 
-func (c *Client) Response() (int, []byte, error) {
+func (c *Client) Response() (int, http.Header, []byte, error) {
 	if c.lastResponse == nil {
-		return 0, nil, errors.New("no request has been sent, please send request before checking response")
+		return 0, nil, nil, errors.New("no request has been sent, please send request before checking response")
 	}
-	return c.lastResponse.Code, c.lastResponse.Body, nil
+	return c.lastResponse.Code, c.lastResponse.Header, c.lastResponse.Body, nil
 }
 
 func (c *Client) Request(method, path string, body []byte) error {
@@ -96,6 +97,6 @@ func (c *Client) Request(method, path string, body []byte) error {
 		return err
 	}
 
-	c.lastResponse = &response{resp.StatusCode, body}
+	c.lastResponse = &response{resp.StatusCode, resp.Header, body}
 	return nil
 }

--- a/resource/http_client.go
+++ b/resource/http_client.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"errors"
+	"net/http"
 
 	httpclient "github.com/alileza/tomato/resource/http/client"
 )
@@ -10,7 +11,7 @@ type HTTPClient interface {
 	Resource
 
 	Request(method, path string, body []byte) error
-	Response() (int, []byte, error)
+	Response() (int, http.Header, []byte, error)
 }
 
 func (m *Manager) GetHTTPClient(resourceName string) (HTTPClient, error) {


### PR DESCRIPTION
Not sure what could be done about it but it would be nice if tomato could tell me that whatever I wrote into my test is not actually supported. 

All we see now is the error from godog:

```
2 scenarios (2 failed, 1 undefined)
5 steps (2 failed, 1 undefined, 2 skipped)
8.374339ms

You can implement step definitions for undefined steps with these snippets:

func responseHeaderShouldBe(arg1, arg2, arg3 string) error {
        return godog.ErrPending
}

func FeatureContext(s *godog.Suite) {
        s.Step(`^"([^"]*)" response header "([^"]*)" should be "([^"]*)"$`, responseHeaderShouldBe)
}
```